### PR TITLE
Add lts file and ecosystem installer in blueprint

### DIFF
--- a/blueprints/ember-cli-ember-ecosystem/index.js
+++ b/blueprints/ember-cli-ember-ecosystem/index.js
@@ -1,3 +1,11 @@
 module.exports = {
-  description: ''
+  description: '',
+  normalizeEntityName: function () {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter
+    // to us
+  },
+  afterInstall: function () {
+    return this.addAddonsToProject({ packages: [{name: 'ember-cli-ecosystem-installer'}] })
+  }
 }

--- a/lts.json
+++ b/lts.json
@@ -1,0 +1,3 @@
+{
+  "ember-frost-core": "0.25.3"
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "child-process-promise": "^2.1.3",
+    "cli-spinner": "^0.2.5",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
@@ -36,7 +38,8 @@
     "ember-truth-helpers": "^1.2.0",
     "eslint": "^3.0.1",
     "eslint-config-frost-standard": "^3.0.0",
-    "loader.js": "^4.0.0"
+    "loader.js": "^4.0.0",
+    "promise": "^7.1.1"
   },
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-ember-ecosystem",
   "version": "0.0.0",
-  "description": "Groups of features that pin dependencies to an LTS range.",
+  "description": "Ember groups of features that pin dependencies to an LTS range.",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Add "fake" LTS file
- Add addon "ember-cli-ecosystem-installer" installation in blueprint
